### PR TITLE
Add Battery Service to Lock

### DIFF
--- a/index.js
+++ b/index.js
@@ -1324,7 +1324,7 @@ HomeSeerAccessory.prototype = {
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 		 
-		    /*
+		    
 		    
           	  if (this.config.batteryRef) {
 			  console.log("Adding a Battery");
@@ -1339,7 +1339,7 @@ HomeSeerAccessory.prototype = {
                 	services.push(batteryService);
 			  console.log("Battery Added");
 			}
-			*/
+			
 			
                 break;
             }

--- a/index.js
+++ b/index.js
@@ -719,6 +719,32 @@ HomeSeerAccessory.prototype = {
         else
             callback(null, 0);
     },
+	
+    getBatteryValue: function (callback) {
+        var ref = this.config.batteryRef;
+        var url = this.access_url + "request=getstatus&ref=" + ref;
+
+        httpRequest(url, 'GET', function (error, response, body) {
+            if (error) {
+                this.log(this.name + ': getBatteryValue function failed: %s', error.message);
+                callback(error, 0);
+            }
+            else {
+                var status = JSON.parse(body);
+                var value = status.Devices[0].value;
+                var minValue = 10;
+
+                this.log(this.name + ': getBatteryValue function succeeded: value=' + value);
+                if (this.config.batteryThreshold) {
+                    minValue = this.config.batteryThreshold;
+                }
+
+		    callback(null, value);
+
+            }
+        }.bind(this));
+    },
+	
 
     getLowBatteryStatus: function (callback) {
         var ref = this.config.batteryRef;
@@ -1333,7 +1359,7 @@ HomeSeerAccessory.prototype = {
                 var batteryService = new Service.BatteryService();
                 batteryService
                     .getCharacteristic(Characteristic.BatteryLevel)
-                    .on('get', this.getLowBatteryStatus.bind(this));
+                    .on('get', this.getBatteryValue.bind(this));
                 batteryService
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));

--- a/index.js
+++ b/index.js
@@ -734,7 +734,7 @@ HomeSeerAccessory.prototype = {
                 var status = JSON.parse(body);
                 var value = status.Devices[0].value;
 
-                this.log("getBatteryValue function succeeded for: " + this.name + "with value= " + value);
+                this.log("getBatteryValue function succeeded for: " + this.name + " with value= " + value);
 
 		callback(null, value);
 

--- a/index.js
+++ b/index.js
@@ -1338,7 +1338,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    Console.log("Pushed battery service data structure is....");
+		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");
 

--- a/index.js
+++ b/index.js
@@ -1169,6 +1169,11 @@ HomeSeerAccessory.prototype = {
                         .addCharacteristic(new Characteristic.ObstructionDetected())
                         .on('get', this.getObstructionDetected.bind(this));
                 }
+                if (this.config.batteryRef) {
+                    doorService
+                        .addCharacteristic(new Characteristic.StatusLowBattery())
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                }                
 
                 this.statusCharacteristic = doorService.getCharacteristic(Characteristic.CurrentPosition);
                 services.push(doorService);

--- a/index.js
+++ b/index.js
@@ -306,7 +306,6 @@ HomeSeerPlatform.prototype = {
                         }
                     }
                 }
-
                 callback(foundAccessories);
             }
         }.bind(this));
@@ -725,8 +724,6 @@ HomeSeerAccessory.prototype = {
     getBatteryValue: function (callback) {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
-
-	    this.log("************* Get Battery Value Called by " + this.name + " with reference " + ref + " *********");
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -737,7 +734,7 @@ HomeSeerAccessory.prototype = {
                 var status = JSON.parse(body);
                 var value = status.Devices[0].value;
 
-                this.log("****" + this.name + ': getBatteryValue function succeeded: value=' + value + "*****");
+                this.log("getBatteryValue function succeeded for: " + this.name + "with value=' + value);
 
 		callback(null, value);
 
@@ -749,8 +746,6 @@ HomeSeerAccessory.prototype = {
     getLowBatteryStatus: function (callback) {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
-	    
-	    this.log("********** Called getLowBatteryStatus function Called by " + this.name + " with reference " + ref + " **********");
 
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -1261,7 +1256,6 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    
 		break;
             }
             case "Thermostat": {
@@ -1337,13 +1331,13 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.LockTargetState)
                     .on('set', this.setLockTargetState.bind(this));
 		    
+		// If a battery is present, make the lockService the primary service before pushing it to the array of services.
+		if (this.config.batteryRef) { lockService.isPrimaryService = true;}
+		    
 		services.push(lockService);
-                this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
+		this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 
-		    // If a battery is present, make the lockService the primary service.
-		    if (this.config.batteryRef) { lockService.isPrimaryService = true;}
-		    
-		    
+		// If batteryRef has been defined, then add a battery service.
 		if (this.config.batteryRef)
 		{
 		this.log("Adding a Battery Service to Lock " + this.name);

--- a/index.js
+++ b/index.js
@@ -734,7 +734,7 @@ HomeSeerAccessory.prototype = {
                 var status = JSON.parse(body);
                 var value = status.Devices[0].value;
 
-                this.log("getBatteryValue function succeeded for: " + this.name + "with value=' + value);
+                this.log("getBatteryValue function succeeded for: " + this.name + "with value= " + value);
 
 		callback(null, value);
 

--- a/index.js
+++ b/index.js
@@ -1531,8 +1531,5 @@ HomeSeerEvent.prototype = {
         return services;
     }
 }
-console.log("*******************************");
-console.log("Printing HomeSeer Platform");
-console.log(HomeSeerPlatform);
-console.log("************** Done *************");
+
 module.exports.platform = HomeSeerPlatform;

--- a/index.js
+++ b/index.js
@@ -1237,7 +1237,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    Console.log("Pushed battery service data structure is....");
+		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");
                 break;

--- a/index.js
+++ b/index.js
@@ -722,7 +722,14 @@ HomeSeerAccessory.prototype = {
 
 // getBatteryValue added to support reading of the Battery Level for locks using the batteryRef reference.
     getBatteryValue: function (callback) {
-        var ref = this.config.batteryRef;
+	    
+	    // If batteryRef is defined, use that to get battery status. 
+	    // Otherwise, assume ref directly identified the HomeSeer battery object.
+	    if (this.config.batteryRef)
+		    	{ var ref = this.config.batteryRef;} 
+	    	else 
+			{ var ref = this.config.ref; }
+	    
         var url = this.access_url + "request=getstatus&ref=" + ref;
 	  	
         httpRequest(url, 'GET', function (error, response, body) {

--- a/index.js
+++ b/index.js
@@ -724,7 +724,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 
-	    console.log("*************" Get Battery Value Called ************ with reference " + ref);
+	    console.log("************* Get Battery Value Called ************ with reference " + ref);
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {

--- a/index.js
+++ b/index.js
@@ -1318,13 +1318,18 @@ HomeSeerAccessory.prototype = {
 		services.push(lockService);
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 
-		    /* Add a battery service. See HomeKitTypes.js at line 2590
-                if (this.config.batteryRef) {
-                    console.log("Configuring a Lock Battery Ref. " + this.config.batteryRef +" with threshold " + this.config.batteryThreshold);
-                    console.log("Configuring the Lock's Battery with config data");
+
+		    
+		    console.log("********************");
+		    console.log("printing the Lock Service configuration data");
+		    console.log(lockService);
+		    console.log("********************");
+		    
+
+		console.log("Configuring an Independent Battery with config data");
 		    console.log(this.config)
 		    console.log("******* End config Data ******");
-		this.config.batteryRef = this.batteryRef;
+		    
                 var batteryService = new Service.BatteryService();
                 batteryService
                     .getCharacteristic(Characteristic.BatteryLevel)
@@ -1333,19 +1338,11 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-			Console.log("Pushed battery service data structure is....");
+		    Console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");
-                }  
-		*/
-		    
-		    console.log("********************");
-		    console.log("printing the Lock Service configuration data");
-		    console.log(lockService);
-		    console.log("********************");
-		    
 
-			
+		    			
                 break;
             }
             case "SecuritySystem": {

--- a/index.js
+++ b/index.js
@@ -1369,6 +1369,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
+		    console.log("******* Configured a Battery with initital value " + getBatteryValue() );
 		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");

--- a/index.js
+++ b/index.js
@@ -1369,7 +1369,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    console.log("******* Configured a Battery with initital value " + this.getBatteryValue() );
+		    console.log("******* Configured a Battery with initital value " + this.getBatteryValue.bind(this) );
 		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");

--- a/index.js
+++ b/index.js
@@ -1331,11 +1331,9 @@ HomeSeerAccessory.prototype = {
 		    console.log("******* End config Data ******");
 		    
                 var batteryService = new Service.BatteryService();
-		    var that = this;
-		    that.config.ref = this.config.batteryRef;
                 batteryService
                     .getCharacteristic(Characteristic.BatteryLevel)
-                    .on('get', this.getValue.bind(that));
+                    .on('get', this.getLowBatteryStatus.bind(this));
                 batteryService
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));

--- a/index.js
+++ b/index.js
@@ -1224,6 +1224,10 @@ HomeSeerAccessory.prototype = {
                 break;
             }
             case "Battery": {
+		console.log("Configuring an Independent Battery with config data");
+		    console.log(this.config)
+		    console.log("******* End config Data ******");
+		    
                 this.config.batteryRef = this.ref;
                 var batteryService = new Service.BatteryService();
                 batteryService
@@ -1233,6 +1237,9 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
+		    Console.log("Pushed battery service data structure is....");
+		    console.log(batteryService);
+		    console.log("End Battery Service Data Structure");
                 break;
             }
             case "Thermostat": {
@@ -1307,47 +1314,37 @@ HomeSeerAccessory.prototype = {
                 lockService
                     .getCharacteristic(Characteristic.LockTargetState)
                     .on('set', this.setLockTargetState.bind(this));
+		    
+		services.push(lockService);
+                this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 
-		    /*
+		    /* Add a battery service. See HomeKitTypes.js at line 2590
                 if (this.config.batteryRef) {
                     console.log("Configuring a Lock Battery Ref. " + this.config.batteryRef +" with threshold " + this.config.batteryThreshold);
-                    lockService
-                    .addService(Service.BatteryService, "Fake Lock Battery")
+                    console.log("Configuring the Lock's Battery with config data");
+		    console.log(this.config)
+		    console.log("******* End config Data ******");
+		this.config.batteryRef = this.batteryRef;
+                var batteryService = new Service.BatteryService();
+                batteryService
                     .getCharacteristic(Characteristic.BatteryLevel)
-                      .on('get', function(callback) {
-		                callback (null, FAKE_LOCK.getBattery());
-                         });
-                    console.log("Added a Battery");
-
+                    .on('get', this.getValue.bind(this));
+                batteryService
+                    .getCharacteristic(Characteristic.StatusLowBattery)
+                    .on('get', this.getLowBatteryStatus.bind(this));
+                services.push(batteryService);
+			Console.log("Pushed battery service data structure is....");
+		    console.log(batteryService);
+		    console.log("End Battery Service Data Structure");
                 }  
 		*/
 		    
-
-		 
-	/*	 Look at AirConditionar_accessory to see how multiple services are added    
-		    
-          	  if (this.config.batteryRef) {
-			  console.log("Adding a Battery");
-			this.config.batteryRef = this.batteryRef;
-                	var batteryService = new Service.BatteryService();
-                	batteryService
-                	    .getCharacteristic(Characteristic.BatteryLevel)
-               	     	.on('get', this.getValue.bind(this));
-                	batteryService
-                    	.getCharacteristic(Characteristic.StatusLowBattery)
-                    	.on('get', this.getLowBatteryStatus.bind(this));
-                	services.push(batteryService);
-			  console.log("Battery Added");
-			}
-	*/	
 		    console.log("********************");
 		    console.log("printing the Lock Service configuration data");
 		    console.log(lockService);
 		    console.log("********************");
 		    
-		    services.push(lockService);
 
-                this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 			
                 break;
             }

--- a/index.js
+++ b/index.js
@@ -303,6 +303,9 @@ HomeSeerPlatform.prototype = {
                         }
                     }
                 }
+		    console.log("*** Found Accessories ****");
+		    console.log(foundAccessories);
+		    console.log("**************************");
                 callback(foundAccessories);
             }
         }.bind(this));

--- a/index.js
+++ b/index.js
@@ -1306,6 +1306,7 @@ HomeSeerAccessory.prototype = {
                     .on('set', this.setLockTargetState.bind(this));
 
                 if (this.config.batteryRef) {
+                    console.log("Configuring a Lock Battery Ref. " + this.config.batteryRef +" with threshold " + this.config.batteryThreshold);
                     lockService
                     .getCharacteristic(Characteristic.BatteryLevel)
                     .on('get', this.getValue.bind(this));

--- a/index.js
+++ b/index.js
@@ -1528,5 +1528,8 @@ HomeSeerEvent.prototype = {
         return services;
     }
 }
-
+console.log("*******************************");
+console.log("Printing HomeSeer Platform");
+console.log(HomeSeerPlatform);
+console.log("************** Done *************");
 module.exports.platform = HomeSeerPlatform;

--- a/index.js
+++ b/index.js
@@ -726,7 +726,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 
-	    console.log("************* Get Battery Value Called by " + this.name + " with reference " + ref + " *********");
+	    this.log("************* Get Battery Value Called by " + this.name + " with reference " + ref + " *********");
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -750,7 +750,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 	    
-	    console.log("********** Called getLowBatteryStatus function Called by " + this.name + " **********");
+	    this.log("********** Called getLowBatteryStatus function Called by " + this.name + " with reference " + ref + " **********");
 
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -1355,9 +1355,9 @@ HomeSeerAccessory.prototype = {
 		    
 if (this.config.batteryRef)
 {
-		console.log("Configuring a Lock Battery with config data");
-		    console.log(this.config)
-		    console.log("******* End config Data ******");
+		this.log("********** Configuring a Lock Battery with config data **********");
+		    this.log(this.config)
+		    this.log("******* End config Data ******");
 		    
                 var batteryService = new Service.BatteryService();
                 batteryService
@@ -1367,10 +1367,10 @@ if (this.config.batteryRef)
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    console.log("******* Configured a Battery with initital value " + this.getBatteryValue.bind(this) );
-		    console.log("Pushed battery service data structure is....");
-		    console.log(batteryService);
-		    console.log("End Battery Service Data Structure");
+		    this.log("******* Configured a Battery with initital value " + this.getBatteryValue.bind(this) );
+		    this.log("Pushed battery service data structure is....");
+		    this.log(batteryService);
+		    this.log("End Battery Service Data Structure");
 }
 		    			
                 break;

--- a/index.js
+++ b/index.js
@@ -1323,7 +1323,8 @@ HomeSeerAccessory.prototype = {
                 services.push(lockService);
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
-		    
+		 
+		    /*
 		    
           	  if (this.config.batteryRef) {
 			  console.log("Adding a Battery");
@@ -1338,6 +1339,7 @@ HomeSeerAccessory.prototype = {
                 	services.push(batteryService);
 			  console.log("Battery Added");
 			}
+			*/
 			
                 break;
             }

--- a/index.js
+++ b/index.js
@@ -1337,8 +1337,12 @@ HomeSeerAccessory.prototype = {
 			  console.log("Battery Added");
 			}
 	*/	
-		                   
-                services.push(lockService);
+		    console.log("********************");
+		    console.log("printing the Lock Service configuration data");
+		    console.log(lockService);
+		    console.log("********************");
+		    
+		    services.push(lockService);
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 			

--- a/index.js
+++ b/index.js
@@ -1319,12 +1319,9 @@ HomeSeerAccessory.prototype = {
                 }  
 		*/
 		    
-               
-                services.push(lockService);
 
-                this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 		 
-		    
+	/*	 Look at AirConditionar_accessory to see how multiple services are added    
 		    
           	  if (this.config.batteryRef) {
 			  console.log("Adding a Battery");
@@ -1339,7 +1336,11 @@ HomeSeerAccessory.prototype = {
                 	services.push(batteryService);
 			  console.log("Battery Added");
 			}
-			
+	*/	
+		                   
+                services.push(lockService);
+
+                this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 			
                 break;
             }

--- a/index.js
+++ b/index.js
@@ -1353,8 +1353,9 @@ HomeSeerAccessory.prototype = {
 		    console.log(lockService);
 		    console.log("********************");
 		    
-
-		console.log("Configuring an Independent Battery with config data");
+if (this.config.batteryRef)
+{
+		console.log("Configuring a Lock Battery with config data");
 		    console.log(this.config)
 		    console.log("******* End config Data ******");
 		    
@@ -1370,7 +1371,7 @@ HomeSeerAccessory.prototype = {
 		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");
-
+}
 		    			
                 break;
             }

--- a/index.js
+++ b/index.js
@@ -724,7 +724,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 
-	    console.log("*************" Get Battery Value Called ************");
+	    console.log("*************" Get Battery Value Called ************ with reference " + ref);
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -752,6 +752,8 @@ HomeSeerAccessory.prototype = {
     getLowBatteryStatus: function (callback) {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
+	    
+	    console.log("********** Called getLowBatteryStatus function **********");
 
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {

--- a/index.js
+++ b/index.js
@@ -1331,9 +1331,11 @@ HomeSeerAccessory.prototype = {
 		    console.log("******* End config Data ******");
 		    
                 var batteryService = new Service.BatteryService();
+		    var that = this;
+		    that.config.ref = this.config.batteryRef;
                 batteryService
                     .getCharacteristic(Characteristic.BatteryLevel)
-                    .on('get', this.getValue.bind(this));
+                    .on('get', this.getValue.bind(that));
                 batteryService
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));

--- a/index.js
+++ b/index.js
@@ -1169,11 +1169,7 @@ HomeSeerAccessory.prototype = {
                         .addCharacteristic(new Characteristic.ObstructionDetected())
                         .on('get', this.getObstructionDetected.bind(this));
                 }
-                if (this.config.batteryRef) {
-                    doorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }                
+             
 
                 this.statusCharacteristic = doorService.getCharacteristic(Characteristic.CurrentPosition);
                 services.push(doorService);
@@ -1308,6 +1304,13 @@ HomeSeerAccessory.prototype = {
                 lockService
                     .getCharacteristic(Characteristic.LockTargetState)
                     .on('set', this.setLockTargetState.bind(this));
+
+                if (this.config.batteryRef) {
+                    lockService
+                        .addCharacteristic(new Characteristic.StatusLowBattery())
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                }  
+                
                 services.push(lockService);
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);

--- a/index.js
+++ b/index.js
@@ -1369,7 +1369,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    console.log("******* Configured a Battery with initital value " + getBatteryValue() );
+		    console.log("******* Configured a Battery with initital value " + this.getBatteryValue() );
 		    console.log("Pushed battery service data structure is....");
 		    console.log(batteryService);
 		    console.log("End Battery Service Data Structure");

--- a/index.js
+++ b/index.js
@@ -726,7 +726,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 
-	    console.log("************* Get Battery Value Called ************ with reference " + ref);
+	    console.log("************* Get Battery Value Called by " + this.name + " with reference " + ref + " *********");
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -736,15 +736,10 @@ HomeSeerAccessory.prototype = {
             else {
                 var status = JSON.parse(body);
                 var value = status.Devices[0].value;
-                var minValue = 10;
 
-                this.log(this.name + ': getBatteryValue function succeeded: value=' + value);
-                if (this.config.batteryThreshold) {
-                    minValue = this.config.batteryThreshold;
-                }
-		    console.log("*****************");
+                this.log("****" + this.name + ': getBatteryValue function succeeded: value=' + value + "*****");
 
-		    callback(null, value);
+		callback(null, value);
 
             }
         }.bind(this));
@@ -755,7 +750,7 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 	    
-	    console.log("********** Called getLowBatteryStatus function **********");
+	    console.log("********** Called getLowBatteryStatus function Called by " + this.name + " **********");
 
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {

--- a/index.js
+++ b/index.js
@@ -1319,19 +1319,14 @@ HomeSeerAccessory.prototype = {
                 }  
 		*/
 		    
-
-		    
-		    
-
-		    
-		    
-                
+               
                 services.push(lockService);
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
 		    
 		    
           	  if (this.config.batteryRef) {
+			  console.log("Adding a Battery");
 			this.config.batteryRef = this.batteryRef;
                 	var batteryService = new Service.BatteryService();
                 	batteryService
@@ -1341,6 +1336,7 @@ HomeSeerAccessory.prototype = {
                     	.getCharacteristic(Characteristic.StatusLowBattery)
                     	.on('get', this.getLowBatteryStatus.bind(this));
                 	services.push(batteryService);
+			  console.log("Battery Added");
 			}
 			
                 break;

--- a/index.js
+++ b/index.js
@@ -306,9 +306,7 @@ HomeSeerPlatform.prototype = {
                         }
                     }
                 }
-		    console.log("*** Found Accessories ****");
-		    console.log(foundAccessories);
-		    console.log("**************************");
+
                 callback(foundAccessories);
             }
         }.bind(this));
@@ -1345,16 +1343,10 @@ HomeSeerAccessory.prototype = {
 		    // If a battery is present, make the lockService the primary service.
 		    if (this.config.batteryRef) { lockService.isPrimaryService = true;}
 		    
-		    console.log("********************");
-		    console.log("printing the Lock Service configuration data");
-		    console.log(lockService);
-		    console.log("********************");
 		    
 		if (this.config.batteryRef)
 		{
-		this.log("********** Configuring a Lock Battery with config data **********");
-		    this.log(this.config)
-		    this.log("******* End config Data ******");
+		this.log("Adding a Battery Service to Lock " + this.name);
 		    
                 var batteryService = new Service.BatteryService();
                 batteryService
@@ -1364,10 +1356,6 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
                 services.push(batteryService);
-		    this.log("******* Configured a Battery with initital value " + this.getBatteryValue.bind(this) );
-		    this.log("Pushed battery service data structure is....");
-		    this.log(batteryService);
-		    this.log("End Battery Service Data Structure");
 		}
 		    			
                 break;

--- a/index.js
+++ b/index.js
@@ -1308,11 +1308,13 @@ HomeSeerAccessory.prototype = {
                 if (this.config.batteryRef) {
                     console.log("Configuring a Lock Battery Ref. " + this.config.batteryRef +" with threshold " + this.config.batteryThreshold);
                     lockService
+                    .addService(Service.BatteryService, "Fake Lock Battery")
                     .getCharacteristic(Characteristic.BatteryLevel)
-                    .on('get', this.getValue.bind(this));
-                    lockService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
+                      .on('get', function(callback) {
+		                callback (null, FAKE_LOCK.getBattery());
+                         });
+                    console.log("Added a Battery");
+
                 }  
                 
                 services.push(lockService);

--- a/index.js
+++ b/index.js
@@ -1305,6 +1305,7 @@ HomeSeerAccessory.prototype = {
                     .getCharacteristic(Characteristic.LockTargetState)
                     .on('set', this.setLockTargetState.bind(this));
 
+		    /*
                 if (this.config.batteryRef) {
                     console.log("Configuring a Lock Battery Ref. " + this.config.batteryRef +" with threshold " + this.config.batteryThreshold);
                     lockService
@@ -1316,11 +1317,32 @@ HomeSeerAccessory.prototype = {
                     console.log("Added a Battery");
 
                 }  
+		*/
+		    
+
+		    
+		    
+
+		    
+		    
                 
                 services.push(lockService);
 
                 this.statusCharacteristic = lockService.getCharacteristic(Characteristic.LockCurrentState);
-
+		    
+		    
+          	  if (this.config.batteryRef) {
+			this.config.batteryRef = this.batteryRef;
+                	var batteryService = new Service.BatteryService();
+                	batteryService
+                	    .getCharacteristic(Characteristic.BatteryLevel)
+               	     	.on('get', this.getValue.bind(this));
+                	batteryService
+                    	.getCharacteristic(Characteristic.StatusLowBattery)
+                    	.on('get', this.getLowBatteryStatus.bind(this));
+                	services.push(batteryService);
+			}
+			
                 break;
             }
             case "SecuritySystem": {

--- a/index.js
+++ b/index.js
@@ -1307,6 +1307,9 @@ HomeSeerAccessory.prototype = {
 
                 if (this.config.batteryRef) {
                     lockService
+                    .getCharacteristic(Characteristic.BatteryLevel)
+                    .on('get', this.getValue.bind(this));
+                    lockService
                         .addCharacteristic(new Characteristic.StatusLowBattery())
                         .on('get', this.getLowBatteryStatus.bind(this));
                 }  

--- a/index.js
+++ b/index.js
@@ -724,6 +724,8 @@ HomeSeerAccessory.prototype = {
         var ref = this.config.batteryRef;
         var url = this.access_url + "request=getstatus&ref=" + ref;
 
+	    console.log("*************" Get Battery Value Called ************");
+	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
                 this.log(this.name + ': getBatteryValue function failed: %s', error.message);
@@ -738,6 +740,7 @@ HomeSeerAccessory.prototype = {
                 if (this.config.batteryThreshold) {
                     minValue = this.config.batteryThreshold;
                 }
+		    console.log("*****************");
 
 		    callback(null, value);
 

--- a/index.js
+++ b/index.js
@@ -156,6 +156,8 @@
 //              "lockJammedValues":[2],         // Optional - List of the HomeSeer device values for a HomeKit lock state=JAMMED
 //              "unlockValue":0,                // Required - HomeSeer device control value to unlock
 //              "lockValue":1                   // Required - HomeSeer device control value to lock
+//              "batteryRef":209,               // Optional - HomeSeer device reference for the lock battery level
+//              "batteryThreshold":35,          // Optional - If lock battery level is below this value, the HomeKit LowBattery characteristic is set to 1.
 //            },
 //            {
 //              "ref":230,                      // Required - HomeSeer Device Reference of a Security System

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": "git://github.com/jvmahon/homebridge"
+    "homebridge": ">=0.4.0"
   },
   "dependencies": {
     "request" : ">=2.75.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "homebridge": ">=0.4.0"
   },
   "dependencies": {
-    "request" : ">=2.75.0",
-    "polling-to-event": ">=2.0.2"
+    "request" : ">=2.83.0",
+    "polling-to-event": ">=2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "homebridge": "git://github.com/jvmahon/homebridge"
   },
   "dependencies": {
     "request" : ">=2.75.0",


### PR DESCRIPTION
Updates to add a battery service to a HomeSeer Lock device. With these updates, a battery service will be added if a batteryRef value is included in the config.json data for the lock accessory. batteryRef should point to the homeseer reference for the lock's battery.  The batteryRef number is usually 1 less than the "ref" value for the lock itself. The locks configuration data in config.json should also include a batteryThreshold value to define value below which the iOS Home app. will warn of low battery. I've found that this should be set relatively high (say 35%) to ensure lock battery is changed in time!