### PR TITLE
Add Battery Service for Locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-[![npm version](https://badge.fury.io/js/homebridge-homeseer-plugin.svg)](https://badge.fury.io/js/homebridge-homeseer-plugin)
+[![npm version](https://badge.fury.io/js/homebridge-homeseer-plugin-2018.svg)](https://badge.fury.io/js/homebridge-homeseer-plugin-2018)
 
 # homebridge-homeseer-plugin
 
+
 Plugin for the [homebridge](https://github.com/nfarina/homebridge) Apple iOS Homekit support application to support integration with the [Homeseer V3](http://www.homeseer.com/home-control-software.html) software
 
-Based on and includes code from [hap-nodejs](https://github.com/KhaosT/HAP-NodeJS) and [homebridge-legacy-plugins](https://github.com/nfarina/homebridge-legacy-plugins)
+Based on and includes code from [hap-nodejs](https://github.com/KhaosT/HAP-NodeJS) and [homebridge-legacy-plugins](https://github.com/nfarina/homebridge-legacy-plugins) and [homebridge-homeseer-plugin](https://github.com/jrhubott/homebridge-homeseer).
+
+Note: This package is a update to the 1.0.17 version of the jrhubott/homebridge-homeseer plugin. This update adds additional battery level indication information for locks and sensor devices and provides for both a % of battery and low battery status information display on the Home Application. Updates have been posted as a Pull Request to jrhubott/homebridge-homeseer. In the event these changes are accepted into the original jrhubott package, this repository will be removed or an out-of-date status indicated.
+
 
 # Installation
 Linux (Ubuntu/Debian based)
 
 1. `sudo npm install homebridge -g`
-2. `sudo npm install homebridge-homeseer-plugin -g`
+2. `sudo npm install -g homebridge-homeseer-plugin-2018`
 
 Windows
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@
 // - Added Window Covering support
 // - Added obstruction support to doors, windows, and windowCoverings
 // V0.11 - 2018/01/13
-// - Added battery support to Lock devices
+// - Added battery support to Lock devices and added added battery services to other devices.
 //
 // Remember to add platform to config.json. 
 //
@@ -725,12 +725,9 @@ HomeSeerAccessory.prototype = {
 	    
 	    // If batteryRef is defined, use that to get battery status. 
 	    // Otherwise, assume ref directly identified the HomeSeer battery object.
-	    if (this.config.batteryRef)
-		    	{ var ref = this.config.batteryRef;} 
-	    	else 
-			{ var ref = this.config.ref; }
-	    
-        var url = this.access_url + "request=getstatus&ref=" + ref;
+	    if (!this.config.batteryRef) { this.config.batteryRef = this.config.ref;} 
+	    	
+	    var url = this.access_url + "request=getstatus&ref=" + this.config.batteryRef;
 	  	
         httpRequest(url, 'GET', function (error, response, body) {
             if (error) {
@@ -1058,132 +1055,243 @@ HomeSeerAccessory.prototype = {
                 var temperatureSensorService = new Service.TemperatureSensor();
                 temperatureSensorService
                     .getCharacteristic(Characteristic.CurrentTemperature)
-                    .on('get', this.getTemperature.bind(this));
+                    .on('get', this.getTemperature.bind(this))
+                    .isPrimaryService = true;
                 temperatureSensorService
                     .getCharacteristic(Characteristic.CurrentTemperature).setProps({ minValue: -100 });
-                if (this.config.batteryRef) {
-                    temperatureSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+
                 services.push(temperatureSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "CarbonMonoxideSensor": {
                 var carbonMonoxideSensorService = new Service.CarbonMonoxideSensor();
                 carbonMonoxideSensorService
                     .getCharacteristic(Characteristic.CarbonMonoxideDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    carbonMonoxideSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(carbonMonoxideSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "CarbonDioxideSensor": {
                 var carbonDioxideSensorService = new Service.CarbonDioxideSensor();
                 carbonDioxideSensorService
                     .getCharacteristic(Characteristic.CarbonDioxideDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    carbonDioxideSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(carbonDioxideSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "ContactSensor": {
                 var contactSensorService = new Service.ContactSensor();
                 contactSensorService
                     .getCharacteristic(Characteristic.ContactSensorState)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    contactSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(contactSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
+
                 break;
             }
             case "MotionSensor": {
                 var motionSensorService = new Service.MotionSensor();
                 motionSensorService
                     .getCharacteristic(Characteristic.MotionDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    motionSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(motionSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "LeakSensor": {
                 var leakSensorService = new Service.LeakSensor();
                 leakSensorService
                     .getCharacteristic(Characteristic.LeakDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    leakSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(leakSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "OccupancySensor": {
                 var occupancySensorService = new Service.OccupancySensor();
                 occupancySensorService
                     .getCharacteristic(Characteristic.OccupancyDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    occupancySensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(occupancySensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "SmokeSensor": {
                 var smokeSensorService = new Service.SmokeSensor();
                 smokeSensorService
                     .getCharacteristic(Characteristic.SmokeDetected)
-                    .on('get', this.getBinarySensorState.bind(this));
-                if (this.config.batteryRef) {
-                    smokeSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getBinarySensorState.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(smokeSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "LightSensor": {
                 var lightSensorService = new Service.LightSensor();
                 lightSensorService
                     .getCharacteristic(Characteristic.CurrentAmbientLightLevel)
-                    .on('get', this.getValue.bind(this));
-                if (this.config.batteryRef) {
-                    lightSensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getValue.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(lightSensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "HumiditySensor": {
                 var humiditySensorService = new Service.HumiditySensor();
                 humiditySensorService
                     .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-                    .on('get', this.getValue.bind(this));
-                if (this.config.batteryRef) {
-                    humiditySensorService
-                        .addCharacteristic(new Characteristic.StatusLowBattery())
-                        .on('get', this.getLowBatteryStatus.bind(this));
-                }
+                    .on('get', this.getValue.bind(this))
+                    .isPrimaryService = true;
+
                 services.push(humiditySensorService);
+
+                // If batteryRef has been defined, then add a battery service.
+                if (this.config.batteryRef) {
+                    this.log("Adding a Battery Service to " + this.name);
+
+                    var batteryService = new Service.BatteryService();
+                    batteryService
+                        .getCharacteristic(Characteristic.BatteryLevel)
+                        .on('get', this.getBatteryValue.bind(this));
+                    batteryService
+                        .getCharacteristic(Characteristic.StatusLowBattery)
+                        .on('get', this.getLowBatteryStatus.bind(this));
+                    services.push(batteryService);
+                }
                 break;
             }
             case "Door": {
@@ -1262,6 +1370,8 @@ HomeSeerAccessory.prototype = {
                 batteryService
                     .getCharacteristic(Characteristic.StatusLowBattery)
                     .on('get', this.getLowBatteryStatus.bind(this));
+		batteryService
+                    .isPrimaryService = true;
                 services.push(batteryService);
 		break;
             }
@@ -1347,7 +1457,7 @@ HomeSeerAccessory.prototype = {
 		// If batteryRef has been defined, then add a battery service.
 		if (this.config.batteryRef)
 		{
-		this.log("Adding a Battery Service to Lock " + this.name);
+		this.log("Adding a Battery Service to " + this.name);
 		    
                 var batteryService = new Service.BatteryService();
                 batteryService

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "homebridge": ">=0.4.0"
   },
   "dependencies": {
-    "request" : ">=2.75.0",
-    "polling-to-event": ">=2.0.2"
+    "request" : ">=2.83.0",
+    "polling-to-event": ">=2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-homeseer-plugin",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Homeseer Plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-homeseer-plugin",
+  "name": "homebridge-homeseer-plugin-2018",
   "version": "1.0.18",
   "description": "Homeseer Plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
@@ -8,10 +8,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:jrhubott/homebridge-homeseer.git"
+    "url": "git@github.com:jvmahon/homebridge-homeseer.git"
   },
   "bugs": {
-    "url": "https://github.com/jrhubott/homebridge-homeseer/issues"
+    "url": "https://github.com/jvmahon/homebridge-homeseer/issues"
   },
   "engines": {
     "node": ">=0.12.0",


### PR DESCRIPTION
Updates to add a battery service to a HomeSeer Lock device. With these updates, a battery service will be added if a batteryRef value is included in the config.json data for the lock accessory. batteryRef should point to the homeseer reference for the lock's battery. The batteryRef number is usually 1 less than the "ref" value for the lock itself. The locks configuration data in config.json should also include a batteryThreshold value to define value below which the iOS Home app. will warn of low battery. I've found that this should be set relatively high (say 35%) to ensure lock battery is changed in time!